### PR TITLE
Ensure that jobs can made visible

### DIFF
--- a/src/JobsView.vala
+++ b/src/JobsView.vala
@@ -43,6 +43,7 @@ public class Printers.JobsView : Gtk.Frame {
         var scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.expand = true;
         scrolled.add (view);
+        scrolled.show_all ();
 
         var cell = new Gtk.CellRendererText ();
         var cellell = new Gtk.CellRendererText ();


### PR DESCRIPTION
This makes sure that the ScrolledWindow is shown so that it can be set to the visible child of the stack.

Fixes #25 