### PR TITLE
Use ListBox instead of ListStore and TreeView

### DIFF
--- a/src/JobsView.vala
+++ b/src/JobsView.vala
@@ -23,7 +23,6 @@
 public class Printers.JobsView : Gtk.Frame {
     private Printer printer;
     private Gtk.ListBox list_box;
-    private Gtk.Stack stack;
 
     public JobsView (Printer printer) {
         this.printer = printer;
@@ -66,11 +65,7 @@ public class Printers.JobsView : Gtk.Frame {
 
         var alert = new Granite.Widgets.AlertView (_("No jobs"), _("There are no jobs on the queue"), "document");
         alert.show_all ();
-
-        stack = new Gtk.Stack ();
-        stack.add_named (scrolled, "jobs");
-        stack.add_named (alert, "no-jobs");
-        stack.set_visible_child_name ("no-jobs");
+        list_box.set_placeholder ((Gtk.Widget) alert);
 
         var jobs = printer.get_jobs (true, CUPS.WhichJobs.ALL);
         foreach (var job in jobs) {
@@ -81,7 +76,6 @@ public class Printers.JobsView : Gtk.Frame {
                     continue;
                 default:
                     add_job (job);
-                    stack.set_visible_child_name ("jobs");
                     continue;
             }
         }
@@ -160,7 +154,7 @@ public class Printers.JobsView : Gtk.Frame {
             }
         });
 
-        job_grid.add (stack);
+        job_grid.add (scrolled);
         job_grid.add (toolbar);
         add (job_grid);
 
@@ -221,12 +215,6 @@ public class Printers.JobsView : Gtk.Frame {
                         continue;
                 }
             }
-        }
-
-        if (list_box.get_children ().length () > 0) {
-            stack.set_visible_child_name ("jobs");
-        } else {
-            stack.set_visible_child_name ("no-jobs");
         }
     }
 

--- a/src/JobsView.vala
+++ b/src/JobsView.vala
@@ -75,7 +75,7 @@ public class Printers.JobsView : Gtk.Frame {
                 case CUPS.IPP.JobState.COMPLETED:
                     continue;
                 default:
-                    add_job (job);
+                    list_box.add (new JobRow (printer, job));
                     continue;
             }
         }
@@ -167,16 +167,11 @@ public class Printers.JobsView : Gtk.Frame {
             var jobs_ = printer.get_jobs (true, CUPS.WhichJobs.ALL);
             foreach (var job in jobs_) {
                 if (job.cjob.id == job_id) {
-                    add_job (job);
+                    list_box.add (new JobRow (printer, job));
                     break;
                 }
             }
         });
-    }
-
-    private void add_job (Job job) {
-        list_box.add (new JobRow (printer, job));
-        list_box.invalidate_sort ();
     }
 
     private void toggle_finished (Gtk.ToggleToolButton button) {
@@ -189,7 +184,7 @@ public class Printers.JobsView : Gtk.Frame {
                     case CUPS.IPP.JobState.CANCELED:
                     case CUPS.IPP.JobState.ABORTED:
                     case CUPS.IPP.JobState.COMPLETED:
-                        add_job (job);
+                        list_box.add (new JobRow (printer, job));
                         continue;
                     default:
                         continue;

--- a/src/JobsView.vala
+++ b/src/JobsView.vala
@@ -278,6 +278,8 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             ((Gtk.Spinner)state).start ();
         }
 
+        job.state_changed.connect (update_state);
+
         grid.attach (state, 3, 0);
 
         add (grid);
@@ -285,7 +287,14 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     }
 
     public void update_state () {
+        if (job.state_icon () != null) {
+            state = new Gtk.Image.from_gicon (job.state_icon (), Gtk.IconSize.MENU);
+        } else {
+            state = new Gtk.Spinner ();
+            ((Gtk.Spinner)state).active = true;
+            ((Gtk.Spinner)state).start ();
+        }
+
         grid.tooltip_text = job.translated_job_state ();
-        state = new Gtk.Image.from_gicon (job.state_icon (), Gtk.IconSize.MENU);
     }
 }

--- a/src/JobsView.vala
+++ b/src/JobsView.vala
@@ -242,11 +242,6 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     private Printer printer;
 
     private Gtk.Grid grid;
-    private Gtk.Image icon;
-    private Gtk.Label title;
-    private Gtk.Label date;
-    private Gtk.Widget state;
-
 
     public JobRow (Printer printer, Job job) {
         this.printer = printer;
@@ -258,10 +253,10 @@ public class Printers.JobRow : Gtk.ListBoxRow {
         grid.row_spacing = 6;
         grid.margin = 6;
 
-        icon = new Gtk.Image.from_gicon (job.get_file_icon (), Gtk.IconSize.MENU);
+        Gtk.Image icon = new Gtk.Image.from_gicon (job.get_file_icon (), Gtk.IconSize.MENU);
         grid.attach (icon, 0, 0);
 
-        title = new Gtk.Label (job.cjob.title);
+        Gtk.Label title = new Gtk.Label (job.cjob.title);
         title.hexpand = true;
         title.halign = Gtk.Align.START;
         title.ellipsize = Pango.EllipsizeMode.END;
@@ -269,9 +264,10 @@ public class Printers.JobRow : Gtk.ListBoxRow {
 
         var date_time = job.get_used_time ();
         string date_string = date_time.format ("%F %T");
-        date = new Gtk.Label (date_string);
+        Gtk.Label date = new Gtk.Label (date_string);
         grid.attach (date, 2, 0);
 
+        Gtk.Widget state;
         if (job.state_icon () != null) {
             state = new Gtk.Image.from_gicon (job.state_icon (), Gtk.IconSize.MENU);
         } else {
@@ -279,12 +275,11 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             ((Gtk.Spinner)state).active = true;
             ((Gtk.Spinner)state).start ();
         }
+        grid.attach (state, 3, 0);
 
         job.state_changed.connect (update_state);
         job.completed.connect (update_state);
         job.stopped.connect (update_state);
-
-        grid.attach (state, 3, 0);
 
         add (grid);
         show_all ();
@@ -299,6 +294,7 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             }
         }
 
+        Gtk.Widget state;
         if (job.state_icon () != null) {
             state = new Gtk.Image.from_gicon (job.state_icon (), Gtk.IconSize.MENU);
         } else {


### PR DESCRIPTION
This uses ListBox in place of ListStore as it better handles random access, whilst ListStore is better for sequential access that only happens once, when removing completed jobs, whereas random accesses happen when a job is paused, resumed, stopped or the selected row is changed, and in this when the state of the job changes as the ListBoxRow makes it trivial to implement. This also has the benefit that it makes the progress Spinner actually spin (we would have needed to pulse the previous one to do this which was not nice to implement.) 

On the UX side it is generally kept the same aside from the Spinner, with the exception of margins: I have added a slight horizontal margin to the jobs, I think it makes them feel more comfortable in their place rather than squashed against the side.
![screenshot from 2017-10-19 22 53 58](https://user-images.githubusercontent.com/18336287/31796482-a19eacbc-b521-11e7-8a21-a42e4e3fcbca.png)
