### PR TITLE
Make jobs visible when adding jobs

### DIFF
--- a/src/JobsView.vala
+++ b/src/JobsView.vala
@@ -217,6 +217,8 @@ public class Printers.JobsView : Gtk.Frame {
                               2, job.translated_job_state (),
                               3, date,
                               4, job);
+
+        stack.set_visible_child_name ("jobs");
     }
 
     private void toggle_finished (Gtk.ToggleToolButton button) {


### PR DESCRIPTION
When a job is created the notification should add the job to the jobs list, however with an empty jobs list that didn't happen as the stack was showing no-jobs, this makes it so that whenever a job is added the visible child is set to jobs.