### PR TITLE
Better handle ink colours

### DIFF
--- a/src/InkLevel.vala
+++ b/src/InkLevel.vala
@@ -70,7 +70,15 @@ public class Printers.InkLevel : Gtk.Grid {
             level.expand = true;
             var context = level.get_style_context ();
             context.add_class ("coloredlevelbar");
+            var split = color.color.split ("#");
+
             var css_color = STYLE_CLASS.printf (color.color);
+            if (split.length > 2) {
+                css_color = STYLE_CLASS.printf ("#" + split[1]);
+            } else if (color.color == "none") {
+                css_color = STYLE_CLASS.printf ("#3689e6");
+            }
+
             var provider = new Gtk.CssProvider ();
             try {
                 provider.load_from_data (css_color, css_color.length);


### PR DESCRIPTION
This is a basic solution to #35, it falls back to Blueberry when the colour is "none", and if there are multiple it will use the first one. This prevents the warning and allows the css to be applied.

Fixes #35.