### PR TITLE
More accurately match printer state to icon

### DIFF
--- a/src/Objects/Printer.vala
+++ b/src/Objects/Printer.vala
@@ -270,7 +270,7 @@ public class Printers.Printer : GLib.Object {
     /**
      * Additional comma-delimited state keywords for the destination such as "media-tray-empty-error" and "toner-low-warning".
      */
-    private string? state_reasons_raw {
+    public string? state_reasons_raw {
         get {
             return CUPS.get_option ("printer-state-reasons", dest.options);
         }

--- a/src/Widgets/PrinterRow.vala
+++ b/src/Widgets/PrinterRow.vala
@@ -70,27 +70,32 @@ public class Printers.PrinterRow : Gtk.ListBoxRow {
     }
 
     private void update_status () {
-        status_label.label = "<span font_size=\"small\">%s</span>".printf (GLib.Markup.escape_text (printer.state_reasons));
+        if (printer.enabled) {
+            status_label.label = "<span font_size=\"small\">%s</span>".printf (GLib.Markup.escape_text (printer.state_reasons));
 
-        switch (printer.state_reasons_raw) {
-            case "offline":
-                status_image.icon_name = "user-offline";
-                break;
-            case "none":
-            case null:
-                status_image.icon_name = "user-available";
-                break;
-            case "developer-low":
-            case "marker-supply-low":
-            case "marker-waste-almost-full":
-            case "media-low":
-            case "opc-near-eol":
-            case "toner-low":
-                status_image.icon_name = "user-away";
-                break;
-            default:
-                status_image.icon_name = "user-busy";
-                break;
+            switch (printer.state_reasons_raw) {
+                case "offline":
+                    status_image.icon_name = "user-offline";
+                    break;
+                case "none":
+                case null:
+                    status_image.icon_name = "user-available";
+                    break;
+                case "developer-low":
+                case "marker-supply-low":
+                case "marker-waste-almost-full":
+                case "media-low":
+                case "opc-near-eol":
+                case "toner-low":
+                    status_image.icon_name = "user-away";
+                    break;
+                default:
+                    status_image.icon_name = "user-busy";
+                    break;
+            }
+        } else {
+            status_image.icon_name = "user-offline";
+            status_label.label = "<span font_size=\"small\">%s</span>".printf (_("Disabled"));
         }
     }
 }

--- a/src/Widgets/PrinterRow.vala
+++ b/src/Widgets/PrinterRow.vala
@@ -71,12 +71,26 @@ public class Printers.PrinterRow : Gtk.ListBoxRow {
 
     private void update_status () {
         status_label.label = "<span font_size=\"small\">%s</span>".printf (GLib.Markup.escape_text (printer.state_reasons));
-        if (printer.is_offline ()) {
-            status_image.icon_name = "user-offline";
-        } else if (printer.enabled) {
-            status_image.icon_name = "user-available";
-        } else {
-            status_image.icon_name = "user-busy";
+
+        switch (printer.state_reasons_raw) {
+            case "offline":
+                status_image.icon_name = "user-offline";
+                break;
+            case "none":
+            case null:
+                status_image.icon_name = "user-available";
+                break;
+            case "developer-low":
+            case "marker-supply-low":
+            case "marker-waste-almost-full":
+            case "media-low":
+            case "opc-near-eol":
+            case "toner-low":
+                status_image.icon_name = "user-away";
+                break;
+            default:
+                status_image.icon_name = "user-busy";
+                break;
         }
     }
 }


### PR DESCRIPTION
Assign icon and override label when printer is disabled. Otherwise, check `printer.state_reasons_raw` to assign an appropriate icon severity

## BEFORE

![screenshot from 2018-04-18 13 48 42 2x](https://user-images.githubusercontent.com/7277719/38957412-697c0858-430f-11e8-9596-c61a7a05364f.png)


## AFTER

![screenshot from 2018-04-18 13 49 11 2x](https://user-images.githubusercontent.com/7277719/38957420-6d0d3b90-430f-11e8-9d95-85de59a60061.png)
