### PR TITLE
Fix issue where printers are disabled upon viewing in plug

### DIFF
--- a/src/PrinterPage.vala
+++ b/src/PrinterPage.vala
@@ -56,7 +56,7 @@ public class Printers.PrinterPage : Granite.SimpleSettingsPage {
         printer.bind_property ("info", this, "title");
         printer.bind_property ("location", this, "description");
 
-        printer.bind_property("enabled", status_switch, "active", BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
+        printer.bind_property ("enabled", status_switch, "active", BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
 
         show_all ();
     }

--- a/src/PrinterPage.vala
+++ b/src/PrinterPage.vala
@@ -56,7 +56,7 @@ public class Printers.PrinterPage : Granite.SimpleSettingsPage {
         printer.bind_property ("info", this, "title");
         printer.bind_property ("location", this, "description");
 
-        status_switch.bind_property ("active", printer, "enabled", BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
+        printer.bind_property("enabled", status_switch, "active", BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
 
         show_all ();
     }


### PR DESCRIPTION
According to the [documentation](https://valadoc.org/gobject-2.0/GLib.BindingFlags.html) the `SYNC_CREATE` flag syncs from the source to the target on creation. In this case, it is important for the printer to be the source of truth and for the switch to be the target. Otherwise the printer gets disabled as soon as you load up this plug. Should close #97 and probably a handful of other related issues.