### PR TITLE
Allow the sender parameter of DBusSignalCallback to be null

### DIFF
--- a/src/CUPSNotifier.vala
+++ b/src/CUPSNotifier.vala
@@ -70,7 +70,7 @@ public class Cups.Notifier : Object {
         });
     }
 
-    private void subscription_callback (DBusConnection connection, string sender_name, string object_path, string interface_name, string signal_name, Variant parameters) {
+    private void subscription_callback (DBusConnection connection, string? sender_name, string object_path, string interface_name, string signal_name, Variant parameters) {
         switch (parameters.n_children ()) {
             case 1:
                 send_server_event (signal_name, parameters);


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/glib/commit/5a74c2f445458c037aa71ac51de3ed6af325a1ab