### PR TITLE
Revert "Control: bump granite dep to 6"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: elementary OS Team <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                gettext,
                libcups2-dev,
-               libgranite-dev (>= 6.0.0),
+               libgranite-dev,
                libgtk-3-dev,
                libswitchboard-2.0-dev,
                meson,


### PR DESCRIPTION
Reverts elementary/switchboard-plug-printers#143

I found this might not be correct here because the packaging version is still 5.5.0, although the library version itself is now 6.0.0. This should fix the gettext actions still failing in this repo even after elementary/actions#59 was fixed.
