### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -28,6 +28,9 @@ namespace Printers {
         private PrinterList list;
 
         public Plug () {
+            GLib.Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");
+
             var settings = new Gee.TreeMap<string, string?> (null, null);
             settings.set ("printer", null);
             Object (category: Category.HARDWARE,

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,3 +1,4 @@
 namespace Build {
 public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+public const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ cups_dep = declare_dependency(dependencies: [cups_lib, cups_vapi])
 
 gettext_data = configuration_data()
 gettext_data.set('GETTEXT_PACKAGE', gettext_name)
+gettext_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 gettext_declaration = configure_file(
     configuration: gettext_data,
     input: 'config.vala.in',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)