### PR TITLE
Use two lines for printer driver info in Add Dialog

### DIFF
--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -342,7 +342,6 @@ public class Printers.AddDialog : Granite.Dialog {
         });
 
         next_button.clicked.connect (() => {
-            warning ("NEXT CLICKED");
             try {
                 var name = temp_device.device_info.replace (" ", "_");
                 name = name.replace ("/", "_");
@@ -353,7 +352,6 @@ public class Printers.AddDialog : Granite.Dialog {
                 }
 
                 var pk_helper = Cups.get_pk_helper ();
-                warning ("adding printer %s, driver %s", name, selected_driver.ppd_name);
                 pk_helper.printer_add (name, uri, selected_driver.ppd_name, description_entry.text, location_entry.text);
                 pk_helper.printer_set_enabled (name, true);
                 pk_helper.printer_set_accept_jobs (name, true);
@@ -532,8 +530,6 @@ public class Printers.AddDialog : Granite.Dialog {
             if (!driver_cancellable.is_cancelled ()) {
                 var row_to_select = find_drivers.end (res);
                 driver_view.select_row (row_to_select);
-            } else {
-                warning ("cancelled");
             }
 
             driver_cancellable = null;

--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -535,7 +535,7 @@ public class Printers.AddDialog : Granite.Dialog {
             } else {
                 warning ("cancelled");
             }
-            
+
             driver_cancellable = null;
         });
 
@@ -554,7 +554,7 @@ public class Printers.AddDialog : Granite.Dialog {
                 if (driver.ppd_make_and_model == selected_make_and_model) {
                    row_to_select = row;
                 }
-            } 
+            }
 
             // This greatly speeds up constructing the list and also allows the function
             // to be cancelled.

--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -46,8 +46,7 @@ public class Printers.AddDialog : Granite.Dialog {
     private Granite.Widgets.AlertView alertview;
     private Gtk.Stack drivers_stack;
     private Gee.LinkedList<Printers.DeviceDriver> drivers;
-    private Gtk.ListStore driver_list_store;
-    private Gtk.TreeView driver_view;
+    private Gtk.ListBox driver_view;
     private Gtk.ListStore make_list_store;
     private Gtk.TreeView make_view;
     private Gtk.ListBox devices_list;
@@ -263,18 +262,9 @@ public class Printers.AddDialog : Granite.Dialog {
         make_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         make_scrolled.add (make_view);
 
-        driver_list_store = new Gtk.ListStore (2, typeof (string), typeof (DeviceDriver));
-
-        driver_view = new Gtk.TreeView.with_model (driver_list_store);
-        driver_view.headers_visible = false;
-        driver_view.get_selection ().mode = Gtk.SelectionMode.BROWSE;
-        driver_view.set_tooltip_column (0);
-        driver_view.set_search_column (0);
-
-        var driver_cellrenderer = new Gtk.CellRendererText ();
-        driver_cellrenderer.ellipsize_set = true;
-        driver_cellrenderer.ellipsize = Pango.EllipsizeMode.END;
-        driver_view.insert_column_with_attributes (-1, null, driver_cellrenderer, "text", 0);
+        // driver_list_store = new ListStore (typeof (DeviceDriver));
+        driver_view = new Gtk.ListBox ();
+        driver_view.set_placeholder (new Gtk.Label (_("Loading…")));
 
         var driver_scrolled = new Gtk.ScrolledWindow (null, null);
         driver_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
@@ -352,6 +342,7 @@ public class Printers.AddDialog : Granite.Dialog {
         });
 
         next_button.clicked.connect (() => {
+            warning ("NEXT CLICKED");
             try {
                 var name = temp_device.device_info.replace (" ", "_");
                 name = name.replace ("/", "_");
@@ -362,6 +353,7 @@ public class Printers.AddDialog : Granite.Dialog {
                 }
 
                 var pk_helper = Cups.get_pk_helper ();
+                warning ("adding printer %s, driver %s", name, selected_driver.ppd_name);
                 pk_helper.printer_add (name, uri, selected_driver.ppd_name, description_entry.text, location_entry.text);
                 pk_helper.printer_set_enabled (name, true);
                 pk_helper.printer_set_accept_jobs (name, true);
@@ -372,19 +364,17 @@ public class Printers.AddDialog : Granite.Dialog {
             destroy ();
         });
 
-        var driver_selection = driver_view.get_selection ();
-        driver_selection.changed.connect (() => {
-            Gtk.TreeModel model;
-            Gtk.TreeIter iter;
-            if (driver_selection.get_selected (out model, out iter)) {
-                var val = Value (typeof (Printers.DeviceDriver));
-                model.get_value (iter, 1, out val);
-                selected_driver = (Printers.DeviceDriver) val.get_object ();
+        driver_view.row_selected.connect ((row) => {
+            if (row != null) {
+                selected_driver = ((DriverRow)row).driver;
                 bool can_go_next = true;
                 can_go_next &= !connection_entry.visible || connection_entry.text.contains ("://");
                 can_go_next &= selected_driver != null;
                 can_go_next &= description_entry.text != "";
                 next_button.sensitive = can_go_next;
+            } else {
+                next_button.sensitive = false;
+                selected_driver = null;
             }
         });
 
@@ -512,9 +502,8 @@ public class Printers.AddDialog : Granite.Dialog {
             make_list_store.get_value (iter, 0, out val);
             populate_driver_list_from_make (val.get_string ());
         }
-        drivers_stack.set_visible_child_name ("drivers");
 
-        make_selection.changed.connect (() => {
+        make_selection.changed.connect_after (() => {
             Gtk.TreeModel model;
             Gtk.TreeIter iter;
             if (make_selection.get_selected (out model, out iter)) {
@@ -528,40 +517,52 @@ public class Printers.AddDialog : Granite.Dialog {
                 populate_driver_list_from_make (val.get_string (), make_and_model);
             }
         });
+
+        drivers_stack.visible_child_name = "drivers";
     }
 
-    private void populate_driver_list_from_make (string make, string? selection = null) {
-        driver_list_store.clear ();
+    private void populate_driver_list_from_make (string make, string? selected_make_and_model = null) {
+        driver_cancellable.cancel ();
+        driver_cancellable = new Cancellable ();
+        driver_view.@foreach ((row) => {
+            driver_view.remove (row);
+        });
+
+        find_drivers.begin (make, selected_make_and_model, (obj, res) => {
+            if (!driver_cancellable.is_cancelled ()) {
+                var row_to_select = find_drivers.end (res);
+                driver_view.select_row (row_to_select);
+            } else {
+                warning ("cancelled");
+            }
+            
+            driver_cancellable = null;
+        });
+
+    }
+
+    private async Gtk.ListBoxRow? find_drivers (string make, string? selected_make_and_model) {
+        Gtk.ListBoxRow? row_to_select = null;
         foreach (var driver in drivers) {
-            if (driver.ppd_make != make) {
-                continue;
-            }
-
-            Gtk.TreeIter iter;
-            driver_list_store.append (out iter);
-            var model = driver.ppd_make_and_model;
-            model = model.replace ("(recommended)", _("(recommended)"));
-            if (driver.ppd_natural_language != null) {
-                ///Translators: The first argument is the driver name, the second is the language
-                model = _("%s (%s)").printf (model, driver.ppd_natural_language);
-            }
-
-            driver_list_store.set (iter, 0, model, 1, driver);
-            if (selection != null && (selection in driver.ppd_make_and_model || selection == driver.get_model_from_id ())) {
-                driver_view.get_selection ().select_iter (iter);
-                driver_view.scroll_to_cell (driver_list_store.get_path (iter), null, true, 0.0f, 0.0f);
-            }
-
             if (driver_cancellable.is_cancelled ()) {
-                return;
+                return null;
             }
+
+            if (driver.ppd_make == make) {
+                var row = new DriverRow (driver);
+                driver_view.add (row);
+                if (driver.ppd_make_and_model == selected_make_and_model) {
+                   row_to_select = row;
+                }
+            } 
+
+            // This greatly speeds up constructing the list and also allows the function
+            // to be cancelled.
+            Idle.add (find_drivers.callback);
+            yield;
         }
 
-        if (selected_driver == null && driver_view.get_selection ().count_selected_rows () < 1) {
-            Gtk.TreeIter iter;
-            driver_list_store.get_iter_first (out iter);
-            driver_view.get_selection ().select_iter (iter);
-        }
+        return row_to_select;
     }
 
     private static int temp_device_list_sort (TempDeviceRow row1, TempDeviceRow row2) {
@@ -640,6 +641,40 @@ public class Printers.AddDialog : Granite.Dialog {
             ((Gtk.Misc)label).xalign = 0;
             grid.add (label);
             add (grid);
+            show_all ();
+        }
+    }
+
+    public class DriverRow : Gtk.ListBoxRow {
+        public DeviceDriver driver { get; construct; }
+        public DriverRow (DeviceDriver driver) {
+            Object (driver: driver);
+        }
+
+        construct {
+            var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+                margin_bottom = 12
+            };
+            var model = driver.ppd_make_and_model;
+            model = model.replace ("(recommended)", _("(recommended)"));
+            var label1 = new Gtk.Label (model) {
+                halign = Gtk.Align.START
+            };
+
+            label1.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+
+            var language = driver.ppd_natural_language;
+            var name = driver.ppd_name;
+            var label2 = new Gtk.Label (("%s - %s").printf (language, name)) {
+                halign = Gtk.Align.START
+            };
+
+            label2.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+
+            box.add (label1);
+            box.add (label2);
+
+            add (box);
             show_all ();
         }
     }

--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -652,29 +652,23 @@ public class Printers.AddDialog : Granite.Dialog {
         }
 
         construct {
-            var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
-                margin_bottom = 12
-            };
             var model = driver.ppd_make_and_model;
             model = model.replace ("(recommended)", _("(recommended)"));
-            var label1 = new Gtk.Label (model) {
-                halign = Gtk.Align.START
+            var model_markup = ("<span size='large' weight='bold'>%s</span>").printf (model);
+
+            var detail_markup = ("<span size='medium' weight='normal'>%s — %s</span>").printf (
+                driver.ppd_natural_language, driver.ppd_name
+            );
+
+            var label = new Gtk.Label ("") {
+                halign = Gtk.Align.START,
+                margin = 6,
+                use_markup = true
             };
 
-            label1.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+            label.set_markup (("%s\n%s").printf (model_markup, detail_markup));
 
-            var language = driver.ppd_natural_language;
-            var name = driver.ppd_name;
-            var label2 = new Gtk.Label (("%s - %s").printf (language, name)) {
-                halign = Gtk.Align.START
-            };
-
-            label2.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
-
-            box.add (label1);
-            box.add (label2);
-
-            add (box);
+            add (label);
             show_all ();
         }
     }

--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -650,9 +650,9 @@ public class Printers.AddDialog : Granite.Dialog {
         construct {
             var model = driver.ppd_make_and_model;
             model = model.replace ("(recommended)", _("(recommended)"));
-            var model_markup = ("<span size='large' weight='bold'>%s</span>").printf (model);
+            var model_markup = GLib.Markup.printf_escaped ("<span size='large' weight='bold'>%s</span>", model);
 
-            var detail_markup = ("<span size='medium' weight='normal'>%s — %s</span>").printf (
+            var detail_markup = GLib.Markup.printf_escaped ("<span size='medium' weight='normal'>%s — %s</span>",
                 driver.ppd_natural_language, driver.ppd_name
             );
 
@@ -662,7 +662,7 @@ public class Printers.AddDialog : Granite.Dialog {
                 use_markup = true
             };
 
-            label.set_markup (("%s\n%s").printf (model_markup, detail_markup));
+            label.set_markup ("%s\n%s".printf (model_markup, detail_markup));
 
             add (label);
             show_all ();

--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -650,21 +650,31 @@ public class Printers.AddDialog : Granite.Dialog {
         construct {
             var model = driver.ppd_make_and_model;
             model = model.replace ("(recommended)", _("(recommended)"));
-            var model_markup = GLib.Markup.printf_escaped ("<span size='large' weight='bold'>%s</span>", model);
 
-            var detail_markup = GLib.Markup.printf_escaped ("<span size='medium' weight='normal'>%s — %s</span>",
-                driver.ppd_natural_language, driver.ppd_name
-            );
-
-            var label = new Gtk.Label ("") {
+            var model_label = new Gtk.Label (model) {
                 halign = Gtk.Align.START,
-                margin = 6,
-                use_markup = true
+                ellipsize = Pango.EllipsizeMode.MIDDLE
             };
 
-            label.set_markup ("%s\n%s".printf (model_markup, detail_markup));
+            var detail_label = new Gtk.Label ("%s — %s".printf (driver.ppd_natural_language, driver.ppd_name)) {
+                halign = Gtk.Align.START,
+                ellipsize = Pango.EllipsizeMode.MIDDLE
+            };
 
-            add (label);
+            unowned var style_context = detail_label.get_style_context ();
+            style_context.add_class (Granite.STYLE_CLASS_SMALL_LABEL);
+            style_context.add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
+            var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+                margin_top = 6,
+                margin_start = 6,
+                margin_bottom = 6,
+                margin_end = 6
+            };
+            box.add (model_label);
+            box.add (detail_label);
+
+            add (box);
             show_all ();
         }
     }

--- a/src/PrinterList.vala
+++ b/src/PrinterList.vala
@@ -94,6 +94,7 @@ public class Printers.PrinterList : Gtk.Grid {
     }
 
     public void add_printer (Printer printer) {
+    warning ("Printer list add printer");
         var row = new PrinterRow (printer);
         list_box.add (row);
         stack.add (row.page);

--- a/src/PrinterList.vala
+++ b/src/PrinterList.vala
@@ -94,7 +94,6 @@ public class Printers.PrinterList : Gtk.Grid {
     }
 
     public void add_printer (Printer printer) {
-    warning ("Printer list add printer");
         var row = new PrinterRow (printer);
         list_box.add (row);
         stack.add (row.page);


### PR DESCRIPTION
Modifies #158 

An attempt to implement @danrabbit 's design for the printer driver info, using a listbox.

Constructing the listbox synchronously resulted in the interface freezing for a noticeable time for e.g. HP as there are nearly 5000 entries in that case. This was improved by making the construction asynchronous and cancellable.