### PR TITLE
Sync job status

### DIFF
--- a/src/CUPSNotifier.vala
+++ b/src/CUPSNotifier.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2015 Pantheon Developers (https://launchpad.net/switchboard-plug-printers)
+ * Copyright 2015 - 2022 elementary, Inc. (https://elementary.io)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/src/CUPSNotifier.vala
+++ b/src/CUPSNotifier.vala
@@ -151,7 +151,7 @@ public class Cups.Notifier : Object {
         var text = parameters.get_child_value (0).get_string ();
         var printer_uri = parameters.get_child_value (1).get_string ();
         var name = parameters.get_child_value (2).get_string ();
-        var state = parameters.get_child_value (3).get_uint32 ();
+        var printer_state = parameters.get_child_value (3).get_uint32 ();
         var state_reasons = parameters.get_child_value (4).get_string ();
         var is_accepting_jobs = parameters.get_child_value (5).get_boolean ();
         var job_id = parameters.get_child_value (6).get_uint32 ();
@@ -161,25 +161,19 @@ public class Cups.Notifier : Object {
         var job_impressions_completed = parameters.get_child_value (10).get_uint32 ();
         switch (signal_name) {
             case "JobCreated":
-                job_created (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
-                break;
-            case "JobCompleted":
-                job_completed (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
-                break;
-            case "JobStopped":
-                job_stopped (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
+                job_created (text, printer_uri, name, printer_state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
                 break;
             case "JobConfigChanged":
-                job_config_changed (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
-                break;
             case "JobProgress":
-                job_progress (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
+                job_progress (text, printer_uri, name, printer_state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
                 break;
+            case "JobCompleted":
+                job_completed (text, printer_uri, name, printer_state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
+                break;
+            case "JobStopped":
             case "JobState":
-                this.job_state (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
-                break;
             case "JobStateChanged":
-                job_state_changed (text, printer_uri, name, state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
+                job_state_changed (text, printer_uri, name, printer_state, state_reasons, is_accepting_jobs, job_id, job_state, job_state_reason, job_name, job_impressions_completed);
                 break;
             default:
                 debug ("Signal `%s` isn't handled by the plug", signal_name);

--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2015 Pantheon Developers (https://launchpad.net/switchboard-plug-printers)
+ * Copyright 2015 - 2022 elementary, Inc. (https://elementary.io)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -34,8 +34,8 @@ public class Printers.Job : GLib.Object {
 
     public Job (CUPS.Job cjob, Printer printer) {
         Object (
-            creation_time: cjob.creation_time > 0 ? new DateTime.from_unix_local (cjob.creation_time) :  new DateTime.now (),
-            completed_time: cjob.completed_time > 0 ? new DateTime.from_unix_local (cjob.completed_time) :  null,
+            creation_time: cjob.creation_time > 0 ? new DateTime.from_unix_local (cjob.creation_time) : new DateTime.now (),
+            completed_time: cjob.completed_time > 0 ? new DateTime.from_unix_local (cjob.completed_time) : null,
             state: cjob.state,
             title: cjob.title,
             printer: printer,
@@ -56,8 +56,7 @@ public class Printers.Job : GLib.Object {
 
     private void on_job_state_changed (
         string text, string printer_uri, string name, uint32 printer_state, string state_reasons, bool is_accepting_jobs,
-        uint32 job_id, uint32 job_state, string job_state_reason, string job_name, uint32 job_impressions_completed)
-    {
+        uint32 job_id, uint32 job_state, string job_state_reason, string job_name, uint32 job_impressions_completed) {
         if (job_id == uid) {
             state = (CUPS.IPP.JobState)job_state;
             if (state == CUPS.IPP.JobState.COMPLETED &&

--- a/src/Objects/Printer.vala
+++ b/src/Objects/Printer.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2015 Pantheon Developers (https://launchpad.net/switchboard-plug-printers)
+ * Copyright 2015 - 2022 elementary, Inc. (https://elementary.io)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/src/Objects/Printer.vala
+++ b/src/Objects/Printer.vala
@@ -322,7 +322,7 @@ public class Printers.Printer : GLib.Object {
 
     public Gee.TreeSet<Job> get_jobs (bool my_jobs, CUPS.WhichJobs whichjobs) {
         var jobs = new Gee.TreeSet<Job> ();
-        unowned CUPS.Job[] cjobs = dest.get_jobs (my_jobs, whichjobs);
+        unowned var cjobs = dest.get_jobs (my_jobs, whichjobs);
         foreach (unowned CUPS.Job cjob in cjobs) {
             var job = new Job (cjob, this);
             jobs.add (job);

--- a/src/Views/JobsView.vala
+++ b/src/Views/JobsView.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2015 Pantheon Developers (https://launchpad.net/switchboard-plug-printers)
+ * Copyright 2015 - 2022 elementary, Inc. (https://elementary.io)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/src/Views/JobsView.vala
+++ b/src/Views/JobsView.vala
@@ -56,7 +56,7 @@ public class Printers.JobsView : Gtk.Frame {
 
             var jobs_ = printer.get_jobs (true, CUPS.WhichJobs.ALL);
             foreach (var job in jobs_) {
-                if (job.cjob.id == job_id) {
+                if (job.uid == job_id) {
                     list_box.add (new JobRow (printer, job));
                     break;
                 }
@@ -65,14 +65,14 @@ public class Printers.JobsView : Gtk.Frame {
     }
 
     static int compare (Gtk.ListBoxRow a, Gtk.ListBoxRow b) {
-        var timea = (((JobRow)a).job.get_used_time ());
-        var timeb = (((JobRow)b).job.get_used_time ());
-        return timeb.compare (timea);
+        var timea = (((JobRow)a).job.get_display_time ());
+        var timeb = (((JobRow)b).job.get_display_time ());
+        return timea.compare (timeb);
     }
 
     [CCode (instance_pos = -1)]
     private void update_header (JobRow row1, JobRow? row2) {
-        if (row1.job.cjob.state == CUPS.IPP.JobState.COMPLETED && (row2 == null || row1.job.cjob.state != row2.job.cjob.state)) {
+        if (row1.job.state == CUPS.IPP.JobState.COMPLETED && (row2 == null || row1.job.state != row2.job.state)) {
             var label = new Gtk.Label (_("Completed Jobs"));
             label.xalign = 0;
             label.margin = 3;

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2015-2018 elementary LLC. (https://elementary.io)
+ * Copyright 2015 - 2022 elementary, Inc. (https://elementary.io)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -116,7 +116,7 @@ public class Printers.JobRow : Gtk.ListBoxRow {
                     critical (e.message);
                 }
             } else {
-                start_pause_button.sensitive = false;
+                critical ("Unexpected job state when trying to pause or resume");
             }
         });
 

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -21,14 +21,15 @@
  */
 
 public class Printers.JobRow : Gtk.ListBoxRow {
-    public Job job { get; construct set; }
+    public Printers.Job job { get; construct set; }
     public Printer printer { get; construct set; }
 
     private Gtk.Grid grid;
     private Gtk.Image job_state_icon;
     private Gtk.Stack action_stack;
+    private Gtk.Label date_label;
 
-    public JobRow (Printer printer, Job job) {
+    public JobRow (Printer printer, Printers.Job job) {
         Object (
             job: job,
             printer: printer
@@ -38,13 +39,12 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     construct {
         var icon = new Gtk.Image.from_gicon (job.get_file_icon (), Gtk.IconSize.MENU);
 
-        var title = new Gtk.Label (job.cjob.title);
+        var title = new Gtk.Label (job.title);
         title.hexpand = true;
         title.halign = Gtk.Align.START;
         title.ellipsize = Pango.EllipsizeMode.END;
 
-        var date_time = job.get_used_time ();
-        var date = new Gtk.Label (Granite.DateTime.get_relative_datetime (date_time));
+        date_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (job.creation_time));
 
         job_state_icon = new Gtk.Image ();
         job_state_icon.gicon = job.state_icon ();
@@ -80,7 +80,7 @@ public class Printers.JobRow : Gtk.ListBoxRow {
         grid.margin_start = grid.margin_end = 6;
         grid.attach (icon, 0, 0);
         grid.attach (title, 1, 0);
-        grid.attach (date, 2, 0);
+        grid.attach (date_label, 2, 0);
         grid.attach (action_stack, 3, 0);
 
         add (grid);
@@ -89,14 +89,12 @@ public class Printers.JobRow : Gtk.ListBoxRow {
         update_state ();
 
         job.state_changed.connect (update_state);
-        job.completed.connect (update_state);
-        job.stopped.connect (update_state);
 
         start_pause_button.clicked.connect (() => {
             unowned Cups.PkHelper pk_helper = Cups.get_pk_helper ();
             if (job.get_hold_until () == "no-hold") {
                 try {
-                    pk_helper.job_set_hold_until (job.cjob.id, "indefinite");
+                    pk_helper.job_set_hold_until (job.uid, "indefinite");
                     start_pause_image.icon_name = "media-playback-start-symbolic";
                     start_pause_button.tooltip_text = _("Resume");
                 } catch (Error e) {
@@ -104,7 +102,7 @@ public class Printers.JobRow : Gtk.ListBoxRow {
                 }
             } else {
                 try {
-                    pk_helper.job_set_hold_until (job.cjob.id, "no-hold");
+                    pk_helper.job_set_hold_until (job.uid, "no-hold");
                     start_pause_image.icon_name = "media-playback-pause-symbolic";
                     start_pause_button.tooltip_text = _("Pause");
                 } catch (Error e) {
@@ -116,7 +114,7 @@ public class Printers.JobRow : Gtk.ListBoxRow {
         cancel_button.clicked.connect (() => {
             unowned Cups.PkHelper pk_helper = Cups.get_pk_helper ();
             try {
-                pk_helper.job_cancel_purge (job.cjob.id, false);
+                pk_helper.job_cancel_purge (job.uid, false);
                 start_pause_button.sensitive = false;
                 cancel_button.sensitive = false;
             } catch (Error e) {
@@ -126,14 +124,6 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     }
 
     private void update_state () {
-        var jobs = printer.get_jobs (true, CUPS.WhichJobs.ALL);
-        foreach (var _job in jobs) {
-            if (_job.cjob.id == job.cjob.id) {
-                job = _job;
-                break;
-            }
-        }
-
         if (job.state_icon () != null) {
             job_state_icon.gicon = job.state_icon ();
             action_stack.visible_child_name = "job-state-icon";
@@ -141,6 +131,10 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             action_stack.visible_child_name = "action-grid";
         }
 
-        grid.tooltip_text = job.translated_job_state ();
+        grid.tooltip_text =  job.translated_job_state ();
+        var time = job.get_display_time ();
+        date_label.label = time.format ("%s %s".printf (Granite.DateTime.get_default_date_format (), Granite.DateTime.get_default_time_format ()));
+
+        changed ();
     }
 }

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -131,7 +131,7 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             action_stack.visible_child_name = "action-grid";
         }
 
-        grid.tooltip_text =  job.translated_job_state ();
+        grid.tooltip_text = job.translated_job_state ();
         var time = job.get_display_time ();
         date_label.label = time.format ("%s %s".printf (Granite.DateTime.get_default_date_format (), Granite.DateTime.get_default_time_format ()));
 


### PR DESCRIPTION
Fixes #71
Fixes #72
Fixes #13 (start/stop buttons)

The linked issue was partly caused by changes in the job status not being properly detected and no `changed ()` signal being emitted when the row was updated.

The issue was fixed in a similar way to #168:
* The CUPS.Job struct that the Printers.Job Object is initialised with is no longer relied on to automatically update. Instead signals from CUPS.Notifier is used to change our own properties on Printers.Job.
* Also the "hold" state of the job is no longer determined by an IPP request (that did not work) but tracked from the initial state and notifier signals.
* Handling of some notifier signals is merged
* The absolute time/date a job was created/completed is displayed except for canceled or aborted jobs.
* When a job row is updated the `changed ()` signal is emitted triggering resorting/updating headers

TODO
* [x] Show job status inline instead of in a tooltip