### PR TITLE
JobRow: Redesign and code clean

### DIFF
--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -163,6 +163,8 @@ public class Printers.Job : GLib.Object {
             case CUPS.IPP.JobState.COMPLETED:
                 return new ThemedIcon ("process-completed");
         }
+
+        return null;
     }
 
     public GLib.Icon get_file_icon () {

--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -153,15 +153,15 @@ public class Printers.Job : GLib.Object {
             case CUPS.IPP.JobState.PENDING:
             case CUPS.IPP.JobState.PROCESSING:
             case CUPS.IPP.JobState.HELD:
-                return null;
-            case CUPS.IPP.JobState.STOPPED:
                 return new ThemedIcon ("media-playback-pause");
+            case CUPS.IPP.JobState.STOPPED:
+                return new ThemedIcon ("media-playback-stop");
             case CUPS.IPP.JobState.CANCELED:
             case CUPS.IPP.JobState.ABORTED:
-                return new ThemedIcon ("process-error-symbolic");
+                return new ThemedIcon ("process-error");
             case CUPS.IPP.JobState.COMPLETED:
             default:
-                return new ThemedIcon ("process-completed-symbolic");
+                return new ThemedIcon ("process-completed");
         }
     }
 

--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -161,7 +161,6 @@ public class Printers.Job : GLib.Object {
             case CUPS.IPP.JobState.ABORTED:
                 return new ThemedIcon ("process-error");
             case CUPS.IPP.JobState.COMPLETED:
-            default:
                 return new ThemedIcon ("process-completed");
         }
     }

--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -154,7 +154,7 @@ public class Printers.Job : GLib.Object {
             case CUPS.IPP.JobState.PROCESSING:
                 return null;
             case CUPS.IPP.JobState.HELD:
-                return new ThemedIcon ("media-playback-pause");
+                return new ThemedIcon ("process-paused");
             case CUPS.IPP.JobState.STOPPED:
             case CUPS.IPP.JobState.CANCELED:
                 return new ThemedIcon ("process-stop");

--- a/src/Objects/Job.vala
+++ b/src/Objects/Job.vala
@@ -152,11 +152,12 @@ public class Printers.Job : GLib.Object {
         switch (state) {
             case CUPS.IPP.JobState.PENDING:
             case CUPS.IPP.JobState.PROCESSING:
+                return null;
             case CUPS.IPP.JobState.HELD:
                 return new ThemedIcon ("media-playback-pause");
             case CUPS.IPP.JobState.STOPPED:
-                return new ThemedIcon ("media-playback-stop");
             case CUPS.IPP.JobState.CANCELED:
+                return new ThemedIcon ("process-stop");
             case CUPS.IPP.JobState.ABORTED:
                 return new ThemedIcon ("process-error");
             case CUPS.IPP.JobState.COMPLETED:

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -144,19 +144,18 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     }
 
     private void update_state () {
-        if (job.state_icon () != null) {
-            job_state_icon.gicon = job.state_icon ();
-            action_revealer.reveal_child = false;
-        } else {
-            if (job.state == CUPS.IPP.JobState.HELD) {
-                start_pause_image.icon_name = "media-playback-start-symbolic";
-                start_pause_button.tooltip_text = _("Resume");
-            } else if (job.state == CUPS.IPP.JobState.PROCESSING) {
-                start_pause_image.icon_name = "media-playback-pause-symbolic";
-                start_pause_button.tooltip_text = _("Pause");
-            }
+        job_state_icon.gicon = job.state_icon ();
 
+        if (job.state == CUPS.IPP.JobState.HELD) {
+            start_pause_image.icon_name = "media-playback-start-symbolic";
+            start_pause_button.tooltip_text = _("Resume");
             action_revealer.reveal_child = true;
+        } else if (job.state == CUPS.IPP.JobState.PROCESSING) {
+            start_pause_image.icon_name = "media-playback-pause-symbolic";
+            start_pause_button.tooltip_text = _("Pause");
+            action_revealer.reveal_child = true;
+        } else {
+            action_revealer.reveal_child = false;
         }
 
         state_label.label = job.translated_job_state ();

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -1,4 +1,3 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
  * Copyright 2015 - 2022 elementary, Inc. (https://elementary.io)
  *
@@ -24,9 +23,10 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     public Printers.Job job { get; construct set; }
     public Printer printer { get; construct set; }
 
-    private Gtk.Grid grid;
+    private Gtk.Button start_pause_button;
     private Gtk.Image job_state_icon;
-    private Gtk.Stack action_stack;
+    private Gtk.Image start_pause_image;
+    private Gtk.Revealer action_revealer;
     private Gtk.Label date_label;
     private Gtk.Label state_label;
 
@@ -38,57 +38,72 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     }
 
     construct {
-        var icon = new Gtk.Image.from_gicon (job.get_file_icon (), Gtk.IconSize.MENU);
+        var icon = new Gtk.Image.from_gicon (job.get_file_icon (), Gtk.IconSize.DND);
 
-        var title = new Gtk.Label (job.title);
-        title.hexpand = true;
-        title.halign = Gtk.Align.START;
-        title.ellipsize = Pango.EllipsizeMode.END;
+        job_state_icon = new Gtk.Image () {
+            gicon = job.state_icon (),
+            halign = Gtk.Align.END,
+            valign = Gtk.Align.END,
+            icon_size = Gtk.IconSize.SMALL_TOOLBAR
+        };
 
-        state_label = new Gtk.Label ("") {
-            hexpand = false,
+        var icon_overlay = new Gtk.Overlay ();
+        icon_overlay.add (icon);
+        icon_overlay.add_overlay (job_state_icon);
+
+        var title = new Gtk.Label (job.title) {
             halign = Gtk.Align.START,
+            hexpand = true,
             ellipsize = Pango.EllipsizeMode.END
         };
 
-        date_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (job.creation_time));
+        state_label = new Gtk.Label ("") {
+            halign = Gtk.Align.START,
+            ellipsize = Pango.EllipsizeMode.END
+        };
+        state_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
-        job_state_icon = new Gtk.Image ();
-        job_state_icon.gicon = job.state_icon ();
-        job_state_icon.halign = Gtk.Align.END;
-        job_state_icon.icon_size = Gtk.IconSize.SMALL_TOOLBAR;
+        date_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (job.creation_time)) {
+            halign = Gtk.Align.END
+        };
+        date_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        var cancel_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-        cancel_button.tooltip_text = _("Cancel");
+        var cancel_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Cancel")
+        };
         cancel_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var start_pause_image = new Gtk.Image ();
-        start_pause_image.icon_name = "media-playback-pause-symbolic";
-        start_pause_image.icon_size = Gtk.IconSize.SMALL_TOOLBAR;
+        start_pause_image = new Gtk.Image.from_icon_name (
+            "media-playback-pause-symbolic",
+            Gtk.IconSize.SMALL_TOOLBAR
+        );
 
-        var start_pause_button = new Gtk.Button ();
-        start_pause_button.image = start_pause_image;
-        start_pause_button.tooltip_text = _("Pause");
+        start_pause_button = new Gtk.Button () {
+            image = start_pause_image,
+            tooltip_text = _("Pause")
+        };
         start_pause_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var action_grid = new Gtk.Grid ();
-        action_grid.add (cancel_button);
-        action_grid.add (start_pause_button);
+        var action_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        action_box.add (cancel_button);
+        action_box.add (start_pause_button);
 
-        action_stack = new Gtk.Stack ();
-        action_stack.hhomogeneous = false;
-        action_stack.add_named (action_grid, "action-grid");
-        action_stack.add_named (job_state_icon, "job-state-icon");
+        action_revealer = new Gtk.Revealer ();
+        action_revealer.add (action_box);
 
-        grid = new Gtk.Grid ();
-        grid.column_spacing = 3;
-        grid.margin = 3;
-        grid.margin_start = grid.margin_end = 6;
-        grid.attach (icon, 0, 0);
+        var grid = new Gtk.Grid () {
+            column_spacing = 3,
+            margin_top = 6,
+            // Visually the same margin since file type icons don't fill the canvas
+            margin_end = 9,
+            margin_bottom = 6,
+            margin_start = 6
+        };
+        grid.attach (icon_overlay, 0, 0, 1, 2);
         grid.attach (title, 1, 0);
-        grid.attach (state_label, 2, 0);
-        grid.attach (date_label, 3, 0);
-        grid.attach (action_stack, 4, 0);
+        grid.attach (state_label, 1, 1);
+        grid.attach (date_label, 2, 0);
+        grid.attach (action_revealer, 2, 1);
 
         add (grid);
         show_all ();
@@ -102,16 +117,12 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             if (job.state == CUPS.IPP.JobState.PROCESSING) {
                 try {
                     pk_helper.job_set_hold_until (job.uid, "indefinite");
-                    start_pause_image.icon_name = "media-playback-start-symbolic";
-                    start_pause_button.tooltip_text = _("Resume");
                 } catch (Error e) {
                     critical (e.message);
                 }
             } else if (job.state == CUPS.IPP.JobState.HELD) {
                 try {
                     pk_helper.job_set_hold_until (job.uid, "no-hold");
-                    start_pause_image.icon_name = "media-playback-pause-symbolic";
-                    start_pause_button.tooltip_text = _("Pause");
                 } catch (Error e) {
                     critical (e.message);
                 }
@@ -135,18 +146,23 @@ public class Printers.JobRow : Gtk.ListBoxRow {
     private void update_state () {
         if (job.state_icon () != null) {
             job_state_icon.gicon = job.state_icon ();
-            action_stack.visible_child_name = "job-state-icon";
+            action_revealer.reveal_child = false;
         } else {
-            action_stack.visible_child_name = "action-grid";
+            if (job.state == CUPS.IPP.JobState.HELD) {
+                start_pause_image.icon_name = "media-playback-start-symbolic";
+                start_pause_button.tooltip_text = _("Resume");
+            } else if (job.state == CUPS.IPP.JobState.PROCESSING) {
+                start_pause_image.icon_name = "media-playback-pause-symbolic";
+                start_pause_button.tooltip_text = _("Pause");
+            }
+
+            action_revealer.reveal_child = true;
         }
 
-        state_label.label = job.state == CUPS.IPP.JobState.COMPLETED ? "" : job.translated_job_state ();
+        state_label.label = job.translated_job_state ();
         var time = job.get_display_time ();
         if (time != null) {
-            date_label.label = time.format ("%s %s".printf (
-                                    Granite.DateTime.get_default_date_format (),
-                                    Granite.DateTime.get_default_time_format ())
-                                );
+            date_label.label = Granite.DateTime.get_relative_datetime (time);
         } else {
             date_label.label = null;
         }

--- a/src/Widgets/JobRow.vala
+++ b/src/Widgets/JobRow.vala
@@ -25,16 +25,21 @@ public class Printers.JobRow : Gtk.ListBoxRow {
 
     private Gtk.Button start_pause_button;
     private Gtk.Image job_state_icon;
-    private Gtk.Image start_pause_image;
     private Gtk.Revealer action_revealer;
     private Gtk.Label date_label;
     private Gtk.Label state_label;
+
+    private static Gtk.SizeGroup size_group;
 
     public JobRow (Printer printer, Printers.Job job) {
         Object (
             job: job,
             printer: printer
         );
+    }
+
+    static construct {
+        size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
     }
 
     construct {
@@ -72,23 +77,24 @@ public class Printers.JobRow : Gtk.ListBoxRow {
             tooltip_text = _("Cancel")
         };
         cancel_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        start_pause_image = new Gtk.Image.from_icon_name (
-            "media-playback-pause-symbolic",
-            Gtk.IconSize.SMALL_TOOLBAR
-        );
+        cancel_button.get_style_context ().add_class (Granite.STYLE_CLASS_ACCENT);
+        cancel_button.get_style_context ().add_class ("red");
 
         start_pause_button = new Gtk.Button () {
-            image = start_pause_image,
-            tooltip_text = _("Pause")
+            valign = Gtk.Align.CENTER
         };
-        start_pause_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var action_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        size_group.add_widget (start_pause_button);
+
+        var action_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3) {
+            margin_start = 6
+        };
         action_box.add (cancel_button);
         action_box.add (start_pause_button);
 
-        action_revealer = new Gtk.Revealer ();
+        action_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
+        };
         action_revealer.add (action_box);
 
         var grid = new Gtk.Grid () {
@@ -102,8 +108,8 @@ public class Printers.JobRow : Gtk.ListBoxRow {
         grid.attach (icon_overlay, 0, 0, 1, 2);
         grid.attach (title, 1, 0);
         grid.attach (state_label, 1, 1);
-        grid.attach (date_label, 2, 0);
-        grid.attach (action_revealer, 2, 1);
+        grid.attach (date_label, 2, 0, 1, 2);
+        grid.attach (action_revealer, 3, 0, 1, 2);
 
         add (grid);
         show_all ();
@@ -147,12 +153,10 @@ public class Printers.JobRow : Gtk.ListBoxRow {
         job_state_icon.gicon = job.state_icon ();
 
         if (job.state == CUPS.IPP.JobState.HELD) {
-            start_pause_image.icon_name = "media-playback-start-symbolic";
-            start_pause_button.tooltip_text = _("Resume");
+            start_pause_button.label = _("Resume");
             action_revealer.reveal_child = true;
         } else if (job.state == CUPS.IPP.JobState.PROCESSING) {
-            start_pause_image.icon_name = "media-playback-pause-symbolic";
-            start_pause_button.tooltip_text = _("Pause");
+            start_pause_button.label = _("Pause");
             action_revealer.reveal_child = true;
         } else {
             action_revealer.reveal_child = false;


### PR DESCRIPTION
Redesign job rows to match rows in other places like Bluetooth settings and Mail

* Use a 32px icon for documents
* Overlay the status icon
* Don't base action availability on the existence of status icons
* More accurate status icons for states like pause, cancel, aborted
* Use `small-label` for status labels
* Always use relative date time and use `dim-label` for date label
* Use label button for pause/resume. Much easier to click right next to the scrollbar or when you're in a panic
* Update pause/resume label on state change, not on button click
* Code style and use Gtk.Box instead of grid, explicit margins to ease Gtk4 porting

## BEFORE
![Screenshot from 2022-06-23 12 42 34](https://user-images.githubusercontent.com/7277719/175384131-13cd1a37-6612-49a5-abf8-bff289de66aa.png)

## AFTER
![Screenshot from 2022-06-23 13 39 33](https://user-images.githubusercontent.com/7277719/175395653-2437abea-ec4f-425a-8d9f-076c348a44ed.png)