### PR TITLE
Pause before purge

### DIFF
--- a/src/Views/JobsView.vala
+++ b/src/Views/JobsView.vala
@@ -127,6 +127,7 @@ public class Printers.JobsView : Gtk.Frame {
             if (response_id == Gtk.ResponseType.OK) {
                 list_box.@foreach ((row) => {
                     var job = ((JobRow)row).job;
+                    job.pause (); // Purging pending/in_progress jobs does not always remove canceled job
                     job.purge ();
                 });
 


### PR DESCRIPTION
Clearing a queue containing pending or in progress jobs sometimes leaves canceled jobs in the queue. Pausing the jobs first seems to fix this.