### PR TITLE
AddDialog: Gtk4 Prep

### DIFF
--- a/src/PrinterList.vala
+++ b/src/PrinterList.vala
@@ -67,9 +67,10 @@ public class Printers.PrinterList : Gtk.Grid {
 
         add_button.clicked.connect (() => {
             if (add_dialog == null) {
-                add_dialog = new Printers.AddDialog ();
-                add_dialog.transient_for = (Gtk.Window) get_toplevel ();
-                add_dialog.show_all ();
+                add_dialog = new Printers.AddDialog () {
+                    modal = true,
+                    transient_for = (Gtk.Window) get_toplevel ()
+                };
 
                 add_dialog.destroy.connect (() => {
                     add_dialog = null;

--- a/src/meson.build
+++ b/src/meson.build
@@ -46,6 +46,7 @@ shared_module(
         dependency('gobject-2.0'),
         dependency('granite', version: '>=6.0.0'),
         dependency('gtk+-3.0'),
+        dependency('libhandy-1'),
         meson.get_compiler('vala').find_library('posix'),
         cups_dep,
         switchboard_dep


### PR DESCRIPTION
Cherry from #164 plus fixes

* Use Hdy.Window instead of Granite.Dialog. Fixes margins since we don't use any dialog functions and don't want the action area. Can replace with Gtk.Window in GTK4, same as Online Accounts dialogs
* Code style
* Use child property
* replace shadow with frame
* Replace grids with boxes
* Vertical form layout with Granite.HeaderLabel for responsive
* Use default size instead of size request
* Replace buttonbox with box