### PR TITLE
PrinterList: GTK4 prep

### DIFF
--- a/src/PrinterList.vala
+++ b/src/PrinterList.vala
@@ -1,33 +1,17 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
-/*-
- * Copyright (c) 2015 Pantheon Developers (https://launchpad.net/switchboard-plug-printers)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
- * Boston, MA 02110-1301, USA.
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2015-2023 elementary, Inc. (https://elementary.io)
  *
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class Printers.PrinterList : Gtk.Grid {
+public class Printers.PrinterList : Gtk.Box {
     public signal void new_printer_page (Gtk.Widget widget);
 
     public Gtk.Stack stack { get; construct; }
-    public bool has_child { get; private set; default=false; }
+    public bool has_child { get; private set; default = false; }
 
-    Gtk.ListBox list_box;
-    private Printers.AddDialog? add_dialog = null;
+    private Gtk.ListBox list_box;
 
     public PrinterList (Gtk.Stack stack) {
         Object (stack: stack);
@@ -35,27 +19,34 @@ public class Printers.PrinterList : Gtk.Grid {
 
     construct {
         orientation = Gtk.Orientation.VERTICAL;
-        expand = true;
+        hexpand = true;
+        vexpand = true;
+
         list_box = new Gtk.ListBox ();
 
-        var scrolled = new Gtk.ScrolledWindow (null, null);
-        scrolled.add (list_box);
-        scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-        scrolled.width_request = 250;
-        scrolled.expand = true;
+        var scrolled = new Gtk.ScrolledWindow (null, null) {
+            child = list_box,
+            hscrollbar_policy = NEVER,
+            width_request = 250,
+            hexpand = true,
+            vexpand = true
+        };
 
-        var actionbar = new Gtk.ActionBar ();
-        actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
+        var add_button_box = new Gtk.Box (HORIZONTAL, 0);
+        add_button_box.add (new Gtk.Image.from_icon_name ("list-add-symbolic", BUTTON));
+        add_button_box.add (new Gtk.Label (_("Add Printer…")));
 
-        var add_button = new Gtk.Button.with_label (_("Add Printer…")) {
-            always_show_image = true,
-            image = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+        var add_button = new Gtk.Button () {
+            child = add_button_box,
             margin_top = 3,
             margin_bottom = 3
         };
         add_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
+        var actionbar = new Gtk.ActionBar ();
+        actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         actionbar.add (add_button);
+
         add (scrolled);
         add (actionbar);
 
@@ -66,16 +57,10 @@ public class Printers.PrinterList : Gtk.Grid {
         });
 
         add_button.clicked.connect (() => {
-            if (add_dialog == null) {
-                add_dialog = new Printers.AddDialog () {
-                    modal = true,
-                    transient_for = (Gtk.Window) get_toplevel ()
-                };
-
-                add_dialog.destroy.connect (() => {
-                    add_dialog = null;
-                });
-            }
+            var add_dialog = new Printers.AddDialog () {
+                modal = true,
+                transient_for = (Gtk.Window) get_toplevel ()
+            };
 
             add_dialog.present ();
         });


### PR DESCRIPTION
* bump copyright header
* Subclass box instead of grid
* code style
* explicit expands
* Do button with label and icon in GTK 4 friendly way
* Remove dialog magic since it's modal
* Replace INLINE_TOOLBAR with FLAT