### PR TITLE
AddDialog: Use Granite.ValidatedEntry, describe errors, DRY

### DIFF
--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -41,6 +41,9 @@ namespace Printers.Translations {
 }
 
 public class Printers.AddDialog : Hdy.Window {
+    private Granite.ValidatedEntry connection_entry;
+    private Granite.ValidatedEntry description_entry;
+    private Gtk.Button add_printer_button;
     private Gtk.Button refresh_button;
     private Gtk.Stack stack;
     private Granite.Widgets.AlertView alertview;
@@ -238,26 +241,47 @@ public class Printers.AddDialog : Hdy.Window {
 
     // Shows the next panel with further configuration
     private void continue_with_tempdevice (TempDevice temp_device) {
-        var connection_label = new Granite.HeaderLabel (_("Connection"));
-
-        var connection_entry = new Gtk.Entry () {
+        connection_entry = new Granite.ValidatedEntry () {
             hexpand = true,
             placeholder_text = "ipp://hostname/ipp/port1"
         };
 
-        var description_label = new Granite.HeaderLabel (_("Description"));
+        var connection_label = new Granite.HeaderLabel (_("Connection")) {
+            mnemonic_widget =  connection_entry
+        };
 
-        var description_entry = new Gtk.Entry () {
+        var connection_error = new ErrorRevealer (
+            _("Connection uri must contain “://“")
+        ) {
+            margin_top = 3
+        };
+        connection_error.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
+
+        description_entry = new Granite.ValidatedEntry () {
             hexpand = true,
+            min_length = 1,
             placeholder_text = _("BrandPrinter X3000"),
             text = temp_device.get_model_from_id () ?? ""
         };
 
-        var location_label = new Granite.HeaderLabel (_("Location"));
+        var description_label = new Granite.HeaderLabel (_("Description")) {
+            mnemonic_widget = description_entry
+        };
+
+        var description_error = new ErrorRevealer (
+            _("Description cannot be empty")
+        ) {
+            margin_top = 3
+        };
+        description_error.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
 
         var location_entry = new Gtk.Entry () {
             hexpand = true,
             placeholder_text = _("Lab 1 or John's desk")
+        };
+
+        var location_label = new Granite.HeaderLabel (_("Location")) {
+            mnemonic_widget = location_entry
         };
 
         var spinner = new Gtk.Spinner () {
@@ -319,10 +343,10 @@ public class Printers.AddDialog : Hdy.Window {
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
 
-        var next_button = new Gtk.Button.with_label (_("Add Printer")) {
+        add_printer_button = new Gtk.Button.with_label (_("Add Printer")) {
             sensitive = false
         };
-        next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        add_printer_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
         var button_box = new Gtk.Box (HORIZONTAL, 6) {
             halign = END,
@@ -330,7 +354,7 @@ public class Printers.AddDialog : Hdy.Window {
         };
         button_box.add (previous_button);
         button_box.add (cancel_button);
-        button_box.add (next_button);
+        button_box.add (add_printer_button);
 
         var device_box = new Gtk.Box (VERTICAL, 0) {
             margin_top = 12,
@@ -340,14 +364,19 @@ public class Printers.AddDialog : Hdy.Window {
         };
         device_box.add (description_label);
         device_box.add (description_entry);
+        device_box.add (description_error);
 
-        if (":" in temp_device.device_uri) {
-            description_entry.grab_focus ();
-        } else {
+        if (!(":" in temp_device.device_uri)) {
+            connection_entry.changed.connect (() => {
+                connection_entry.is_valid = connection_entry.text.contains ("://");
+                connection_error.reveal_child = !connection_entry.is_valid;
+                validate_form ();
+            });
+
             connection_entry.text = temp_device.device_uri;
             device_box.add (connection_label);
             device_box.add (connection_entry);
-            connection_entry.grab_focus ();
+            device_box.add (connection_error);
         }
 
         device_box.add (location_label);
@@ -369,13 +398,13 @@ public class Printers.AddDialog : Hdy.Window {
             destroy ();
         });
 
-        next_button.clicked.connect (() => {
+        add_printer_button.clicked.connect (() => {
             try {
                 var name = temp_device.device_info.replace (" ", "_");
                 name = name.replace ("/", "_");
                 name = name.replace ("#", "_");
                 var uri = temp_device.device_uri;
-                if (connection_entry.visible) {
+                if (connection_entry.parent != null) {
                     uri = connection_entry.text;
                 }
 
@@ -393,32 +422,26 @@ public class Printers.AddDialog : Hdy.Window {
         driver_view.row_selected.connect ((row) => {
             if (row != null) {
                 selected_driver = ((DriverRow)row).driver;
-                bool can_go_next = true;
-                can_go_next &= !connection_entry.visible || connection_entry.text.contains ("://");
-                can_go_next &= selected_driver != null;
-                can_go_next &= description_entry.text != "";
-                next_button.sensitive = can_go_next;
+                validate_form ();
             } else {
-                next_button.sensitive = false;
+                add_printer_button.sensitive = false;
                 selected_driver = null;
             }
         });
 
-        description_entry.changed.connect (() => {
-            bool can_go_next = true;
-            can_go_next &= !connection_entry.visible || connection_entry.text.contains ("://");
-            can_go_next &= selected_driver != null;
-            can_go_next &= description_entry.text != "";
-            next_button.sensitive = can_go_next;
-        });
+        description_entry.changed.connect (validate_form);
+        description_entry.bind_property (
+            "is-valid", description_error, "reveal-child", INVERT_BOOLEAN | SYNC_CREATE
+        );
+    }
 
-        connection_entry.changed.connect (() => {
-            bool can_go_next = true;
-            can_go_next &= !connection_entry.visible || connection_entry.text.contains ("://");
-            can_go_next &= selected_driver != null;
-            can_go_next &= description_entry.text != "";
-            next_button.sensitive = can_go_next;
-        });
+    private void validate_form () {
+        bool can_go_next = true;
+        can_go_next &= connection_entry.parent == null || connection_entry.is_valid;
+        can_go_next &= selected_driver != null;
+        can_go_next &= description_entry.is_valid;
+
+        add_printer_button.sensitive = can_go_next;
     }
 
     // Retreives all the drivers from the CUPS server.

--- a/src/Dialogs/AddDialog.vala
+++ b/src/Dialogs/AddDialog.vala
@@ -247,7 +247,7 @@ public class Printers.AddDialog : Hdy.Window {
         };
 
         var connection_label = new Granite.HeaderLabel (_("Connection")) {
-            mnemonic_widget =  connection_entry
+            mnemonic_widget = connection_entry
         };
 
         var connection_error = new ErrorRevealer (

--- a/src/Widgets/ErrorRevealer.vala
+++ b/src/Widgets/ErrorRevealer.vala
@@ -1,0 +1,33 @@
+private class Printers.ErrorRevealer : Gtk.Box {
+    public Gtk.Label label_widget { get; construct; }
+
+    public string label { get; construct set; }
+    public bool reveal_child { get; set; default = false; }
+
+    public ErrorRevealer (string label) {
+        Object (label: label);
+    }
+
+    construct {
+        label_widget = new Gtk.Label ("") {
+            justify = RIGHT,
+            max_width_chars = 55,
+            use_markup = true,
+            wrap = true,
+            xalign = 1
+        };
+        label_widget.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
+
+        var revealer = new Gtk.Revealer () {
+            child = label_widget,
+            transition_type = CROSSFADE,
+            halign = END,
+            hexpand = true
+        };
+
+        bind_property ("reveal-child", revealer, "reveal-child", SYNC_CREATE);
+        bind_property ("label", label_widget, "label", SYNC_CREATE);
+
+        add (revealer);
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ plug_files = files(
     'Views/JobsView.vala',
     'Views/SetupView.vala',
     'Views/SuppliesView.vala',
+    'Widgets/ErrorRevealer.vala',
     'Widgets/InkLevel.vala',
     'Widgets/JobRow.vala',
     'Widgets/PrinterRow.vala'


### PR DESCRIPTION
* Use Granite.ValidatedEntry to give feedback about the validation state of the form
* Add error description text
* DRY form validation logic
* Don't rely on connection_entry.visible for validation since widgets are visible by default in GTK4. Instead check if the widget is parented
* Set mnemonic widgets for screen reader

![Screenshot from 2023-10-23 13 52 17](https://github.com/elementary/switchboard-plug-printers/assets/7277719/f8e71818-0f9a-4c7f-9735-89bdfe22636d)
![Screenshot from 2023-10-23 13 51 59](https://github.com/elementary/switchboard-plug-printers/assets/7277719/d4464b5e-d8fd-4a3a-8813-47640a2b6b16)
![Screenshot from 2023-10-23 13 51 46](https://github.com/elementary/switchboard-plug-printers/assets/7277719/47cbf21d-facd-44ff-ba97-266ad0c86cd5)
